### PR TITLE
Fix \uXXXX codes in composer.json

### DIFF
--- a/app/src/Setup.php
+++ b/app/src/Setup.php
@@ -23,8 +23,8 @@ use Ramsey\Skeleton\Task\Questions;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Twig_Environment;
+use Twig_Extension_Escaper;
 use Twig_Loader_Filesystem;
-use Twig_SimpleFilter;
 
 /**
  * `Setup` is a static class for use with the Composer post-create-project event.
@@ -43,7 +43,13 @@ class Setup
         $finder = new Finder();
 
         $twig = static::getTwigEnvironment();
-        $twig->addFilter(new Twig_SimpleFilter('addslashes', 'addslashes'));
+        /** @var Twig_Extension_Escaper $extension */
+        $extension = $twig->getExtension(Twig_Extension_Escaper::class);
+        $extension->setEscaper('json', static function ($env, string $string) {
+            $encoded = json_encode($string, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+            return $encoded ? substr($encoded, 1, -1) : '';
+        });
 
         $prompt = static::getPrompt($io, $filesystem, $finder);
         $prompt->setQuestions(new Questions\InstallQuestions());

--- a/app/tests/SetupTest.php
+++ b/app/tests/SetupTest.php
@@ -20,8 +20,11 @@ class SetupTest extends TestCase
             'packageName' => 'foo/bar',
         ];
 
+        $extension = \Mockery::mock(\Twig_Extension::class);
+        $extension->expects()->setEscaper('json', anInstanceOf(\Closure::class));
+
         $twig = \Mockery::mock(\Twig_Environment::class, [
-            'addFilter' => null,
+            'getExtension' => $extension,
         ]);
 
         $prompt = \Mockery::mock(Prompt::class, [

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require": {
         "php": "^7.2",
+        "ext-json": "*",
         "symfony/filesystem": "^4.2",
         "symfony/finder": "^4.2",
         "twig/twig": "^2.10"

--- a/skeleton/composer.json.twig
+++ b/skeleton/composer.json.twig
@@ -1,23 +1,23 @@
 {
-    "name": "{{ packageName|escape('js') }}",
-    "description": "{{ packageDescription|escape('js') }}",
+    "name": "{{ packageName|escape('json') }}",
+    "description": "{{ packageDescription|escape('json') }}",
     "type": "library",
-    "keywords": [{% for keyword in keywords|split(',') %}"{{ keyword|trim|escape('js') }}"{% if not loop.last %}, {% endif %}{% endfor %}],
-    "homepage": "https://github.com/{{ githubUsername|escape('js') }}/{{ githubProject|escape('js') }}",
+    "keywords": [{% for keyword in keywords|split(',') %}"{{ keyword|trim|escape('json') }}"{% if not loop.last %}, {% endif %}{% endfor %}],
+    "homepage": "https://github.com/{{ githubUsername|escape('json') }}/{{ githubProject|escape('json') }}",
     "license": "MIT",
     "authors": [
         {
-            "name": "{{ authorName|escape('js') }}",
-            "email": "{{ authorEmail|escape('js') }}",
-            "homepage": "{{ authorUrl|escape('js') }}"
+            "name": "{{ authorName|escape('json') }}",
+            "email": "{{ authorEmail|escape('json') }}",
+            "homepage": "{{ authorUrl|escape('json') }}"
         }
     ],
     "support": {
-        "docs": "https://{{ githubUsername|escape('js') }}.github.io/{{ githubProject|escape('js') }}/",
-        "issues": "https://github.com/{{ githubUsername|escape('js') }}/{{ githubProject|escape('js') }}/issues",
-        "rss": "https://github.com/{{ githubUsername|escape('js') }}/{{ githubProject|escape('js') }}/releases.atom",
-        "source": "https://github.com/{{ githubUsername|escape('js') }}/{{ githubProject|escape('js') }}.git",
-        "wiki": "https://github.com/{{ githubUsername|escape('js') }}/{{ githubProject|escape('js') }}/wiki"
+        "docs": "https://{{ githubUsername|escape('json') }}.github.io/{{ githubProject|escape('json') }}/",
+        "issues": "https://github.com/{{ githubUsername|escape('json') }}/{{ githubProject|escape('json') }}/issues",
+        "rss": "https://github.com/{{ githubUsername|escape('json') }}/{{ githubProject|escape('json') }}/releases.atom",
+        "source": "https://github.com/{{ githubUsername|escape('json') }}/{{ githubProject|escape('json') }}.git",
+        "wiki": "https://github.com/{{ githubUsername|escape('json') }}/{{ githubProject|escape('json') }}/wiki"
     },
     "require": {
         "php": "^7.2"
@@ -32,12 +32,12 @@
     },
     "autoload": {
         "psr-4": {
-            "{{ namespace|escape('js') }}\\": "src/"
+            "{{ namespace|escape('json') }}\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "{{ namespace|escape('js') }}\\Test\\": "tests/"
+            "{{ namespace|escape('json') }}\\Test\\": "tests/"
         }
     },
     "scripts": {


### PR DESCRIPTION
It fixes #1 

## Description
It adds a twig escaper for **json** based on json_encode instead of standard twig **js** encoder. So a new dependency "ext-json" was added.

## Motivation and Context
To fix #1. Because it was really annoying.

## How Has This Been Tested?
Unit tests pass. I've created a new project and checked it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer run test` locally, and there were no failures or errors.
