### PR TITLE
Add codecov GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,3 +65,7 @@ jobs:
               env:
                   CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
               continue-on-error: true
+            - name: Codecov
+              uses: codecov/codecov-action@v1
+              with:
+                file: ${{github.workspace}}/build/logs/clover.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,5 +67,3 @@ jobs:
               continue-on-error: true
             - name: Codecov
               uses: codecov/codecov-action@v1
-              with:
-                file: ${{github.workspace}}/build/logs/clover.xml

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
     <a href="https://github.com/ramsey/php-library-skeleton/blob/master/LICENSE"><img src="https://img.shields.io/packagist/l/ramsey/php-library-skeleton.svg?style=flat-square&colorB=darkcyan" alt="Read License"></a>
     <a href="https://packagist.org/packages/ramsey/php-library-skeleton/stats"><img src="https://img.shields.io/packagist/dt/ramsey/php-library-skeleton.svg?style=flat-square&colorB=darkmagenta" alt="Package downloads on Packagist"></a>
     <a href="https://phpc.chat/channel/ramsey"><img src="https://img.shields.io/badge/phpc.chat-%23ramsey-darkslateblue?style=flat-square" alt="Chat with the maintainers"></a>
+    <br>
+    <a href="https://codecov.io/gh/ramsey/php-library-skeleton">
+        <img src="https://codecov.io/gh/ramsey/php-library-skeleton/branch/master/graph/badge.svg" alt="Codecov Code Coverage" />
+    </a>
 </p>
 <!-- BADGES_END -->
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <a href="https://phpc.chat/channel/ramsey"><img src="https://img.shields.io/badge/phpc.chat-%23ramsey-darkslateblue?style=flat-square" alt="Chat with the maintainers"></a>
     <br>
     <a href="https://codecov.io/gh/ramsey/php-library-skeleton">
-        <img src="https://codecov.io/gh/ramsey/php-library-skeleton/branch/master/graph/badge.svg" alt="Codecov Code Coverage" />
+        <img src="https://img.shields.io/codecov/c/gh/ramsey/php-library-skeleton?label=codecov&logo=codecov&style=flat-square" alt="Codecov Code Coverage" />
     </a>
 </p>
 <!-- BADGES_END -->


### PR DESCRIPTION
This Pull Request adds Codecov as a GitHub Action. I've verified that it works on a fork of this repo here:

* GitHub Actions output: https://github.com/hootener/php-library-skeleton/pull/1/checks?check_run_id=983229952
* Commits for this branch on Codecov: https://codecov.io/gh/hootener/php-library-skeleton/commits
* Forked PR with Codecov comment:  https://github.com/hootener/php-library-skeleton/pull/1

Happy to answer any other questions :), and kudos on the 100% code coverage!